### PR TITLE
chore: ignore modern js syntax (es6+, jsx)

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,10 @@
+src/
+_mock/
+bin/
+coverage/
+dist/
+src/
+test/
+server.js
+webpack.dev.config.js
+webpack.prod.config.js


### PR DESCRIPTION
[PATCH]: фикс хаунда, чтобы не ругался на новый синтаксис js (es6+ и jsx). Бизнес логика не затронута. Исключительно инфраструктурная правка.